### PR TITLE
Volumes and bind mounts

### DIFF
--- a/code/SPUC/config/print.config
+++ b/code/SPUC/config/print.config
@@ -2,4 +2,4 @@
 # Available variables are: count, time, location, brightness, units
 # The values of these variables will be replaced if wrapped in curly braces.
 # Lines beginning with # are ignored.
-::::: {time} Unicorn spotted at {location}!! Brightness: {brightness} {units}
+::::: Unicorn spotted at {location}!! Brightness: {brightness} {units}

--- a/episodes/docker-cli-toolkit.Rmd
+++ b/episodes/docker-cli-toolkit.Rmd
@@ -19,7 +19,7 @@ we need to build up our toolkit of Docker commands that allow us to perform the 
 
 To run an image, first we need to download it. You may remember that, in Docker, this is known as *pulling* an image.
 
-Let’s try pulling the SPUC container that we used before:
+Let's try pulling the SPUC container that we used before:
 ```bash
 docker pull spuacv/spuc:latest
 ```


### PR DESCRIPTION
Reviewed text for volumes and mounts.

Env variables can actually be modified in docker desktop, and i forgot to cover it!
Should we move to the toolkit chapter?

Also, docker run -it <cmd> cannot be done in Desktop, but is in toolkit... should we move that somplace else, and put together with "parameters"?