### PR TITLE
Fix Docker Hub link for Space Purple Unicorn Counter image

### DIFF
--- a/episodes/introduction.Rmd
+++ b/episodes/introduction.Rmd
@@ -76,7 +76,7 @@ and encouraging your local community to join in the count!
 </div>
 
 You can use the *Space Purple Unicorn Counter* (**SPUC**) container image for your service,
-which you can find on [Docker Hub](https://hub.docker.com/r/spua/spuc).
+which you can find on [Docker Hub](https://hub.docker.com/r/spuacv/spuc).
 
 This image provides an API, which can be hit to add an event to the sightings record.
 The `location` and `brightness` of the unicorn need to be passed as parameters of a put request.


### PR DESCRIPTION
This PR fixes an incorrect hyperlink address in `episodes/introduction.Rmd`.

The original link address ([https://hub.docker.com/r/spua/spuc](https://hub.docker.com/r/spua/spuc)) leads to a 404 page. This PR changes the link address to [https://hub.docker.com/r/spuacv/spuc](https://hub.docker.com/r/spuacv/spuc), which I think is correct.

Please let me know if I am mistaken.

Kind regards,
Daniel.